### PR TITLE
fix drawing not rendered on direct page load

### DIFF
--- a/src/drawio.tsx
+++ b/src/drawio.tsx
@@ -119,9 +119,9 @@ const Drawio: FC<DrawioProps> = ({
     const json = JSON.stringify(data)
     el.current!.dataset.mxgraph = json
     setTip('')
-    requestAnimationFrame(() => {
-      GraphViewer.createViewerForElement(el.current!)
-    }, 0)
+    requestIdleCallback(() => {
+      GraphViewer.createViewerForElement(el.current)
+    })
   }, [])
   return (
     <div className="docusaurus-plugin-drawio">

--- a/src/drawio.tsx
+++ b/src/drawio.tsx
@@ -119,7 +119,7 @@ const Drawio: FC<DrawioProps> = ({
     const json = JSON.stringify(data)
     el.current!.dataset.mxgraph = json
     setTip('')
-    setTimeout(() => {
+    requestAnimationFrame(() => {
       GraphViewer.createViewerForElement(el.current!)
     }, 0)
   }, [])


### PR DESCRIPTION
Probably some sort of race condition. No clue. Swapping `setTimeout()` for `requestIdleCallback()` seems to fix it.

Please make sure these boxes are checked before submitting your PR

* [x] Make sure local test / build is ok
* [x] Make sure ts type complete
* [x] add necessary comments
